### PR TITLE
Histogram aggregation

### DIFF
--- a/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
@@ -1,13 +1,6 @@
 package io.corbel.resources.rem.dao;
 
-import io.corbel.lib.queries.request.AverageResult;
-import io.corbel.lib.queries.request.CountResult;
-import io.corbel.lib.queries.request.MaxResult;
-import io.corbel.lib.queries.request.MinResult;
-import io.corbel.lib.queries.request.Pagination;
-import io.corbel.lib.queries.request.ResourceQuery;
-import io.corbel.lib.queries.request.Sort;
-import io.corbel.lib.queries.request.SumResult;
+import io.corbel.lib.queries.request.*;
 import io.corbel.resources.rem.model.GenericDocument;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.resmi.exception.MongoAggregationException;
@@ -61,6 +54,8 @@ public interface ResmiDao {
     MaxResult max(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field);
 
     MinResult min(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field);
+
+    HistogramResult histogram(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field);
 
     void moveRelation(ResourceUri uri, RelationMoveOperation relationMoveOperation);
 

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
@@ -55,7 +55,7 @@ public interface ResmiDao {
 
     MinResult min(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field);
 
-    HistogramResult histogram(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field);
+    HistogramResult histogram(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, Optional<Pagination> pagination, Optional<Sort> sort, String field);
 
     void moveRelation(ResourceUri uri, RelationMoveOperation relationMoveOperation);
 

--- a/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
@@ -67,7 +67,8 @@ public class DefaultResmiService implements ResmiService {
             case $MIN:
                 return resmiDao.min(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)), ((Min) operation).getField());
             case $HISTOGRAM:
-                return resmiDao.histogram(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)), ((Histogram)operation).getField());
+                return resmiDao.histogram(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)),
+                        Optional.ofNullable(apiParameters.getPagination()), apiParameters.getSort(), ((Histogram)operation).getField());
             default:
                 throw new RuntimeException("Aggregation operation not supported: " + operation.getOperator());
         }

--- a/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
@@ -1,12 +1,6 @@
 package io.corbel.resources.rem.service;
 
-import io.corbel.lib.queries.request.Aggregation;
-import io.corbel.lib.queries.request.AggregationResult;
-import io.corbel.lib.queries.request.Average;
-import io.corbel.lib.queries.request.Max;
-import io.corbel.lib.queries.request.Min;
-import io.corbel.lib.queries.request.ResourceQuery;
-import io.corbel.lib.queries.request.Sum;
+import io.corbel.lib.queries.request.*;
 import io.corbel.resources.rem.dao.NotFoundException;
 import io.corbel.resources.rem.dao.RelationMoveOperation;
 import io.corbel.resources.rem.dao.ResmiDao;
@@ -72,6 +66,8 @@ public class DefaultResmiService implements ResmiService {
                 return resmiDao.max(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)), ((Max) operation).getField());
             case $MIN:
                 return resmiDao.min(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)), ((Min) operation).getField());
+            case $HISTOGRAM:
+                return resmiDao.histogram(resourceUri, operation.operate(apiParameters.getQueries().orElse(null)), ((Histogram)operation).getField());
             default:
                 throw new RuntimeException("Aggregation operation not supported: " + operation.getOperator());
         }


### PR DESCRIPTION
Implemented histogram aggregation in RESMI. 

Exmaple:

```
GET /v1.0/kite/resource/kite:Space/56372a8c98686b152cc50095/kite:data?api:aggregation={"$histogram":"Dose_Form"} HTTP/1.1
Host: localhost:8080
Accept: application/json
```
Response:
```
[
  {
    "id": "LIQUID.",
    "count": 149
  },
  {
    "id": "SYRUP",
    "count": 3874
  },
  {
    "id": "INGESTABLE INSULIN",
    "count": 1
  },
  {
    "id": "LIQUID CALIBRATED MGS",
    "count": 6
  },
  {
    "id": "CREAM",
    "count": 2
  },
  {
    "id": "USES CREAM 1 TO 2X AS NEEDED TO HANDS",
    "count": 1
  },
  {
    "id": "IM",
    "count": 1
  },
  {
    "id": "GEL CAPS",
    "count": 1
  },
  {
    "id": "GELCAPS",
    "count": 1
  },
  {
    "id": "OUNCES",
    "count": 1
  },
  {
    "id": "TABLESPOON",
    "count": 22
  },
  {
    "id": "TEASPOON",
    "count": 23
  },
  {
    "id": "USES IN NEBULIZER MACHINE",
    "count": 1
  },
  {
    "id": "1-2 TABLETS",
    "count": 1
  },
  {
    "id": "99- UNKNOWN",
    "count": 10
  },
  {
    "id": "LIQUID",
    "count": 11104
  },
  {
    "id": "IV",
    "count": 7
  },
  {
    "id": "PATCH",
    "count": 15
  },
  {
    "id": "WAFER",
    "count": 15695
  },
  {
    "id": "DROP",
    "count": 6
  },
  {
    "id": "SPRAY/SQUIRT",
    "count": 417
  },
  {
    "id": "INHALE UNTIL NONE LEFT",
    "count": 4
  },
  {
    "id": "CAPLET",
    "count": 9
  },
  {
    "id": "SUPPOSITORY",
    "count": 184
  },
  {
    "id": "LOZENGE",
    "count": 5
  },
  {
    "id": "OUNCE",
    "count": 14
  },
  {
    "id": "GEL",
    "count": 1
  },
  {
    "id": "POWDER",
    "count": 17
  },
  {
    "id": "PUFF",
    "count": 4466
  },
  {
    "id": "INJECTION",
    "count": 30
  },
  {
    "id": "SHOT",
    "count": 19
  },
  {
    "id": "UNKNOWN",
    "count": 115
  },
  {
    "id": "LOTION/OINTMENT",
    "count": 23
  },
  {
    "count": 19
  },
  {
    "id": "POINT 7ML LIQUID",
    "count": 1
  },
  {
    "id": "CAPSULE",
    "count": 410
  },
  {
    "id": "GELCAP",
    "count": 18
  },
  {
    "id": "SOFTGELS",
    "count": 2
  },
  {
    "id": "TABLET",
    "count": 6190
  }
]
```


NOTE: Requires: https://github.com/corbel-platform/lib-queries/pull/2