### PR TITLE
Make allowDiskUse aggregation option configurable

### DIFF
--- a/resmi/src/main/java/io/corbel/resources/rem/resmi/ioc/ResmiIoc.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/resmi/ioc/ResmiIoc.java
@@ -66,9 +66,10 @@ public class ResmiIoc extends DefaultMongoConfiguration {
     }
 
     @Bean
-    public ResmiDao mongoResmiDao(AggregationResultsFactory<JsonElement> aggregationResultsFactory) throws Exception {
+    public ResmiDao mongoResmiDao(AggregationResultsFactory<JsonElement> aggregationResultsFactory,
+                                  @Value("${resmi.mongodb.aggregations.allowDiskUse}") boolean allowDiskUse) throws Exception {
         return new MongoResmiDao(mongoTemplate(), getJsonObjectMongoWriteConverter(), getNamespaceNormilizer(), getMongoResmiOrder(),
-                aggregationResultsFactory);
+                aggregationResultsFactory, allowDiskUse);
     }
 
     @Bean

--- a/resmi/src/main/resources/resmi/defaults.properties
+++ b/resmi/src/main/resources/resmi/defaults.properties
@@ -21,6 +21,7 @@ resmi.mongodb.slaveOk=true
 # Uncomment this if you want to use a password for MongoDB
 # resmi.mongodb.username=
 # resmi.mongodb.password=
+resmi.mongodb.aggregations.allowDiskUse=false
 
 # Text search configuration
 # values are: disabled|elasticsearch|mongo

--- a/resmi/src/test/java/io/corbel/resources/rem/dao/MongoResmiDaoTest.java
+++ b/resmi/src/test/java/io/corbel/resources/rem/dao/MongoResmiDaoTest.java
@@ -79,7 +79,7 @@ import static org.mockito.Mockito.*;
     public void setup() {
         when(defaultNameNormalizer.normalize(anyString())).then(returnsFirstArg());
         mongoResmiDao = Mockito.spy(new MongoResmiDao(mongoOperations, jsonObjectMongoWriteConverter, defaultNameNormalizer, resmiOrderMock,
-                new JsonAggregationResultsFactory(new Gson())));
+                new JsonAggregationResultsFactory(new Gson()), false));
     }
 
     @Test


### PR DESCRIPTION
Right now this option will only be use for group and combine aggregations (if configured via property resmi.mongodb.aggregations.allowDiskUse)
