### PR TITLE
Resources service locator

### DIFF
--- a/rem-api/src/main/java/io/corbel/resources/rem/plugin/RemPlugin.java
+++ b/rem-api/src/main/java/io/corbel/resources/rem/plugin/RemPlugin.java
@@ -1,5 +1,6 @@
 package io.corbel.resources.rem.plugin;
 
+import io.corbel.resources.rem.service.ServiceLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -29,6 +30,8 @@ public abstract class RemPlugin implements InitializingBean {
     @Autowired protected Mode mode;
 
     @Autowired protected RemService remService;
+
+    @Autowired protected ServiceLocator serviceLocator;
 
     @Autowired protected RemRegistry registry;
 

--- a/rem-api/src/main/java/io/corbel/resources/rem/service/DefaultServiceLocator.java
+++ b/rem-api/src/main/java/io/corbel/resources/rem/service/DefaultServiceLocator.java
@@ -1,0 +1,27 @@
+package io.corbel.resources.rem.service;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public class DefaultServiceLocator implements ServiceLocator {
+
+    private Map<Class<?>, Object> registry = new ConcurrentHashMap<>();
+
+    @Override
+    public <T> void publish(Class<T> publishClass, T service) {
+        if(registry.containsKey(publishClass)){
+            throw new IllegalStateException("Service of type "+publishClass+" is already published in service locator");
+        }
+        registry.put(publishClass, service);
+    }
+
+    @Override
+    public <T> Optional<T> resolve(Class<T> type) {
+        return Optional.ofNullable((T) registry.get(type));
+    }
+
+}

--- a/rem-api/src/main/java/io/corbel/resources/rem/service/ServiceLocator.java
+++ b/rem-api/src/main/java/io/corbel/resources/rem/service/ServiceLocator.java
@@ -1,0 +1,30 @@
+package io.corbel.resources.rem.service;
+
+import java.util.Optional;
+
+/**
+ * This basic service locator can be used for REM plugins to publish services that other REM plugins can use.
+ * -- Use with care!
+ *
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public interface ServiceLocator {
+
+    /**
+     * Publish a service. Make sure you use the most generic interface as the publishClass
+     * @param service The service instance
+     * @param publishClass The interface (or class) under which the service is published
+     * @param <T> The type of the service
+     * @throws IllegalStateException if there is already a service of the same type published on the service locator
+     */
+    <T> void publish(Class<T> publishClass, T service);
+
+    /**
+     * Get an instance of the service of the specified type
+     * @param type The type of the service
+     * @param <T>
+     * @return an Optional instance of the service
+     */
+    <T> Optional<T> resolve(Class<T> type);
+
+}

--- a/rem-api/src/test/java/io/corbel/resources/rem/service/DefaultServiceLocatorTest.java
+++ b/rem-api/src/test/java/io/corbel/resources/rem/service/DefaultServiceLocatorTest.java
@@ -1,0 +1,38 @@
+package io.corbel.resources.rem.service;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.fest.assertions.api.Assertions.*;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public class DefaultServiceLocatorTest {
+
+    private ServiceLocator serviceLocator;
+
+    @Before
+    public void setup() {
+        serviceLocator = new DefaultServiceLocator();
+    }
+
+    @Test
+    public void testPublishResolve() {
+        TestService service = new TestService() {};
+        serviceLocator.publish(TestService.class, service);
+        assertThat(serviceLocator.resolve(TestService.class)).isEqualTo(Optional.of(service));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testErrorWhenAlreadyPublished() {
+        TestService service = new TestService() {};
+        serviceLocator.publish(TestService.class, service);
+        serviceLocator.publish(TestService.class, service);
+    }
+
+    interface TestService {}
+
+}

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/DefaultMongoResmiDao.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/DefaultMongoResmiDao.java
@@ -1,0 +1,535 @@
+package io.corbel.resources.rem.dao;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import io.corbel.lib.mongo.JsonObjectMongoWriteConverter;
+import io.corbel.lib.mongo.utils.GsonUtil;
+import io.corbel.lib.queries.mongo.builder.CriteriaBuilder;
+import io.corbel.lib.queries.request.*;
+import io.corbel.resources.rem.dao.builder.MongoAggregationBuilder;
+import io.corbel.resources.rem.model.GenericDocument;
+import io.corbel.resources.rem.model.RelationDocument;
+import io.corbel.resources.rem.model.ResourceUri;
+import io.corbel.resources.rem.resmi.exception.InvalidApiParamException;
+import io.corbel.resources.rem.utils.JsonUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.expression.spel.SpelParseException;
+
+import java.util.*;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
+
+
+/**
+ * @author Alberto J. Rubio
+ *
+ */
+public class DefaultMongoResmiDao implements MongoResmiDao {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultMongoResmiDao.class);
+
+    private static final String ID = "id";
+    private static final String _ID = "_id";
+
+    private static final String RELATION_CONCATENATION = ".";
+    private static final String DOMAIN_CONCATENATION = "__";
+    private static final String EMPTY_STRING = "";
+    private static final String EXPIRE_AT = "_expireAt";
+    private static final String CREATED_AT = "_createdAt";
+    private static final String COUNT = "count";
+    private static final String AVERAGE = "average";
+    private static final String SUM = "sum";
+    public static final String $INC = "$inc";
+
+    private static final int MONGO_DOUBLE_TYPE = 1;
+    private static final int MONGO_INT_TYPE = 16;
+    private static final int MONGO_LONG_TYPE = 18;
+
+
+    private final MongoOperations mongoOperations;
+    private final JsonObjectMongoWriteConverter jsonObjectMongoWriteConverter;
+    private final NamespaceNormalizer namespaceNormalizer;
+    private final ResmiOrder resmiOrder;
+    private final AggregationResultsFactory<JsonElement> aggregationResultsFactory;
+    private final boolean allowDiskUse;
+
+    public DefaultMongoResmiDao(MongoOperations mongoOperations, JsonObjectMongoWriteConverter jsonObjectMongoWriteConverter,
+                                NamespaceNormalizer namespaceNormalizer, ResmiOrder resmiOrder, AggregationResultsFactory<JsonElement> aggregationResultsFactory,
+                                boolean allowDiskUse) {
+        this.mongoOperations = mongoOperations;
+        this.jsonObjectMongoWriteConverter = jsonObjectMongoWriteConverter;
+        this.namespaceNormalizer = namespaceNormalizer;
+        this.resmiOrder = resmiOrder;
+        this.aggregationResultsFactory = aggregationResultsFactory;
+        this.allowDiskUse = allowDiskUse;
+    }
+
+    @Override
+    public boolean existsResources(ResourceUri uri) {
+        return mongoOperations.exists(Query.query(Criteria.where(_ID).is(uri.getTypeId())), getMongoCollectionName(uri));
+    }
+
+    @Override
+    public <T> T findResource(ResourceUri uri, Class<T> entityClass) {
+        return mongoOperations.findById(uri.getTypeId(), entityClass, getMongoCollectionName(uri));
+    }
+
+    @Override
+    public <T> List<T> findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass) throws InvalidApiParamException {
+        final MongoResmiQueryBuilder mongoResmiQueryBuilder = new MongoResmiQueryBuilder();
+        try {
+            mongoResmiQueryBuilder.query(resourceQueries.orElse(null)).pagination(pagination.orElse(null)).sort(sort.orElse(null));
+        } catch (PatternSyntaxException pse) {
+            throw new InvalidApiParamException(pse.getMessage());
+        }
+        if (textSearch.isPresent() && StringUtils.isNoneEmpty(textSearch.get()))
+        {
+            mongoResmiQueryBuilder.textSearch(textSearch.get());
+        }
+        final Query query = mongoResmiQueryBuilder.build();
+        LOG.debug("findCollection Query executed : " + query.getQueryObject().toString());
+        return mongoOperations.find(query, entityClass, getMongoCollectionName(uri));
+    }
+
+    @Override
+    public <T> List<T> findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass) throws InvalidApiParamException {
+        final MongoResmiQueryBuilder mongoResmiQueryBuilder = new MongoResmiQueryBuilder();
+
+        if (uri.getRelationId() != null) {
+            mongoResmiQueryBuilder.relationDestinationId(uri.getRelationId());
+        }
+
+        try {
+            mongoResmiQueryBuilder.relationSubjectId(uri).query(resourceQueries.orElse(null)).pagination(pagination.orElse(null))
+                    .sort(sort.orElse(null));
+        } catch (PatternSyntaxException pse) {
+            throw new InvalidApiParamException(pse.getMessage());
+        }
+
+
+        if (textSearch.isPresent() && StringUtils.isNoneEmpty(textSearch.get())) {
+            mongoResmiQueryBuilder.textSearch(textSearch.get());
+        }
+
+        final Query query = mongoResmiQueryBuilder.build();
+        query.fields().exclude(_ID);
+
+        LOG.debug("findRelation Query executed : " + query.getQueryObject().toString());
+        return mongoOperations.find(query, entityClass, getMongoCollectionName(uri));
+    }
+
+
+    @Override
+    public <T> List<T> aggregate(ResourceUri resourceUri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass, AggregationOperation... operations) {
+        MongoAggregationBuilder builder = new MongoAggregationBuilder();
+        builder.match(resourceUri, resourceQueries, textSearch);
+        Arrays.asList(operations).forEach(builder::withOperation);
+
+        if (sort.isPresent()) {
+            builder.sort(sort.get().getDirection().toString(),  sort.get().getField());
+        }
+
+        if (pagination.isPresent()) {
+            builder.pagination(pagination.get());
+        }
+
+        Aggregation aggregation = builder.build();
+
+        if(allowDiskUse) {
+            aggregation = withAllowDiskUseOption(aggregation);
+        }
+        return mongoOperations.aggregate(aggregation, getMongoCollectionName(resourceUri), entityClass).getMappedResults();
+    }
+
+    private List<DBObject> aggregate(ResourceUri resourceUri, Optional<List<ResourceQuery>> resourceQueries,  AggregationOperation... operations) {
+        return aggregate(resourceUri, resourceQueries, Optional.empty(), Optional.empty(), Optional.empty(), DBObject.class, operations);
+    }
+
+
+    private Aggregation withAllowDiskUseOption(Aggregation aggregation) {
+        return aggregation.withOptions(new AggregationOptions.Builder().allowDiskUse(true).build());
+    }
+
+    @Override
+    public <T> List<T> findAll(ResourceUri uri, Class<T> entityClass) {
+        return mongoOperations.findAll(entityClass, getMongoCollectionName(uri));
+    }
+
+    @Override
+    public void updateCollection(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
+        updateMulti(getMongoCollectionName(uri), entity, Optional.of(resourceQueries));
+    }
+
+    @Override
+    public void updateResource(ResourceUri uri, JsonObject entity) {
+        findAndModify(getMongoCollectionName(uri), Optional.of(uri.getTypeId()), entity, true, Optional.empty());
+    }
+
+    @Override
+    public boolean conditionalUpdateResource(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
+        JsonObject saved = findAndModify(getMongoCollectionName(uri), Optional.of(uri.getTypeId()), entity, false, Optional.of(resourceQueries));
+        return saved != null;
+    }
+
+    private void updateMulti(String collection, JsonObject entity, Optional<List<ResourceQuery>> resourceQueries) {
+        Update update = updateFromJsonObject(entity, Optional.empty());
+        Query query = getQueryFromResourceQuery(resourceQueries, Optional.empty());
+        mongoOperations.updateMulti(query, update, JsonObject.class, collection);
+    }
+
+    private Query getQueryFromResourceQuery(Optional<List<ResourceQuery>> resourceQueries, Optional<String> id) {
+        MongoResmiQueryBuilder builder = id.map(identifier -> new MongoResmiQueryBuilder().id(identifier)).orElse(new MongoResmiQueryBuilder());
+
+        if (resourceQueries.isPresent()) {
+            builder.query(resourceQueries.get());
+        }
+
+        return builder.build();
+    }
+
+    private JsonObject findAndModify(String collection, Optional<String> id, JsonObject entity, boolean upsert, Optional<List<ResourceQuery>> resourceQueries) {
+        Update update = updateFromJsonObject(entity, id);
+        Query query = (id.isPresent()) ? getQueryFromResourceQuery(resourceQueries, id) : Query.query(Criteria.where(_ID).exists(false));
+
+        return mongoOperations.findAndModify(query, update, FindAndModifyOptions.options().upsert(upsert).returnNew(true), JsonObject.class, collection);
+    }
+
+    @Override
+    public void saveResource(ResourceUri uri, Object entity) {
+        mongoOperations.save(entity, getMongoCollectionName(uri));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Update updateFromJsonObject(JsonObject entity, Optional<String> id) {
+        Update update = new Update();
+
+        if (id.isPresent()) {
+            entity.remove(ID);
+            if (entity.entrySet().isEmpty()) {
+                update.set(_ID, id);
+            }
+        }
+
+        if (entity.has(CREATED_AT)) {
+            JsonPrimitive createdAt = entity.get(CREATED_AT).getAsJsonPrimitive();
+            entity.remove(CREATED_AT);
+            update.setOnInsert(CREATED_AT, GsonUtil.getPrimitive(createdAt));
+        }
+
+        if (entity.has($INC) && entity.get($INC).isJsonObject()) {
+            for (Map.Entry<String, JsonElement> entry : entity.getAsJsonObject($INC).entrySet()) {
+                update.inc(entry.getKey(), entry.getValue().getAsLong());
+            }
+            entity.remove($INC);
+        }
+
+        jsonObjectMongoWriteConverter.convert(entity).toMap().forEach((key, value) -> update.set((String) key, value));
+        entity.entrySet().stream().filter(entry -> entry.getValue().isJsonNull()).forEach(entry -> update.unset(entry.getKey()));
+
+        return update;
+    }
+
+    @Override
+    public void upsertRelation(ResourceUri uri, JsonObject entity) throws NotFoundException {
+        if (!existsResources(new ResourceUri(uri.getDomain(), uri.getType(), uri.getTypeId()))) {
+            throw new NotFoundException("The resource does not exist");
+        }
+
+        JsonObject relationJson = JsonRelation.create(uri.getTypeId(), uri.getRelationId(), entity);
+        JsonObject storedRelation = findModifyOrCreateRelation(uri, relationJson);
+
+        if (!storedRelation.has("_order")) {
+            JsonObject order = new JsonObject();
+            resmiOrder.addNextOrderInRelation(uri, order);
+            findAndModify(getMongoCollectionName(uri), Optional.ofNullable(storedRelation.get("id").getAsString()), order, false,
+                    Optional.empty());
+        }
+    }
+
+    @Override
+    public boolean conditionalUpdateRelation(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
+        JsonObject saved = findModifyRelation(uri, entity, resourceQueries);
+        return saved != null;
+    }
+
+    private JsonObject findModifyOrCreateRelation(ResourceUri uri, JsonObject entity) {
+        if (uri.getRelationId() != null) {
+            Criteria criteria = Criteria.where(JsonRelation._SRC_ID).is(uri.getTypeId()).and(JsonRelation._DST_ID).is(uri.getRelationId());
+            Update update = updateFromJsonObject(entity, Optional.<String>empty());
+            update.set(JsonRelation._SRC_ID, uri.getTypeId());
+            update.set(JsonRelation._DST_ID, uri.getRelationId());
+            return mongoOperations.findAndModify(new Query(criteria), update, FindAndModifyOptions.options().upsert(true).returnNew(true),
+                    JsonObject.class, getMongoCollectionName(uri));
+        } else {
+            mongoOperations.save(entity, getMongoCollectionName(uri));
+            return entity;
+        }
+    }
+    private JsonObject findModifyRelation(ResourceUri uri, JsonObject entity,  List<ResourceQuery>
+            resourceQueries) {
+        Query query = new MongoResmiQueryBuilder().query(resourceQueries).build();
+        Criteria criteria = Criteria.where(JsonRelation._SRC_ID).is(uri.getTypeId()).and(JsonRelation._DST_ID).is(uri.getRelationId());
+        query.addCriteria(criteria);
+        Update update = updateFromJsonObject(entity, Optional.<String>empty());
+        update.set(JsonRelation._SRC_ID, uri.getTypeId());
+        update.set(JsonRelation._DST_ID, uri.getRelationId());
+        return mongoOperations.findAndModify(query, update, FindAndModifyOptions.options().upsert(false).returnNew
+                        (true),
+                JsonObject.class, getMongoCollectionName(uri));
+    }
+
+    @Override
+    public void ensureExpireIndex(ResourceUri uri) {
+        mongoOperations.indexOps(getMongoCollectionName(uri)).ensureIndex(new Index().on(EXPIRE_AT, Direction.ASC).expire(0));
+    }
+
+    @Override
+    public void ensureIndex(ResourceUri uri, IndexDefinition indexDefinition) {
+        mongoOperations.indexOps(getMongoCollectionName(uri)).ensureIndex(indexDefinition);
+    }
+
+
+    @Override
+    public JsonObject deleteResource(ResourceUri uri) {
+        Criteria criteria = Criteria.where(_ID).is(uri.getTypeId());
+        return findAndRemove(uri, criteria);
+    }
+
+    @Override
+    public List<GenericDocument> deleteCollection(ResourceUri uri, Optional<List<ResourceQuery>> queries) {
+        List<ResourceQuery> resourceQueries = queries.orElse(Collections.<ResourceQuery>emptyList());
+        Criteria criteria = CriteriaBuilder.buildFromResourceQueries(resourceQueries);
+        return findAllAndRemove(uri, criteria, GenericDocument.class);
+    }
+
+    @Override
+    public List<GenericDocument> deleteRelation(ResourceUri uri, Optional<List<ResourceQuery>> queries) {
+        List<ResourceQuery> resourceQueries = queries.orElse(Collections.<ResourceQuery>emptyList());
+        Criteria criteria = CriteriaBuilder.buildFromResourceQueries(resourceQueries);
+        if (!uri.isTypeWildcard()) {
+            criteria = criteria.and(JsonRelation._SRC_ID).is(uri.getTypeId());
+        }
+        if (uri.getRelationId() != null) {
+            criteria = criteria.and(JsonRelation._DST_ID).is(uri.getRelationId());
+        }
+
+        return findAllAndRemove(uri, criteria, RelationDocument.class).stream().map(document -> {
+            return new GenericDocument().setId(document.getDstId());
+        }).collect(Collectors.<GenericDocument>toList());
+    }
+
+    private <T extends GenericDocument> List<T> findAllAndRemove(ResourceUri resourceUri, Criteria criteria, Class<T> clazz) {
+        return mongoOperations.findAllAndRemove(new Query(criteria), clazz, getMongoCollectionName(resourceUri));
+    }
+
+    private JsonObject findAndRemove(ResourceUri resourceUri, Criteria criteria) {
+        return mongoOperations.findAndRemove(new Query(criteria), JsonObject.class, getMongoCollectionName(resourceUri));
+    }
+
+
+    @Override
+    public void moveRelation(ResourceUri uri, RelationMoveOperation relationMoveOperation) {
+        resmiOrder.moveRelation(uri, relationMoveOperation);
+    }
+
+
+    @Override
+    public JsonElement count(ResourceUri resourceUri, List<ResourceQuery> resourceQueries) {
+        Query query = new MongoResmiQueryBuilder().relationSubjectId(resourceUri).query(resourceQueries).build();
+        if (resourceUri.isRelation()) {
+            query.fields().exclude(_ID).exclude(JsonRelation._SRC_ID);
+        }
+        LOG.debug("Query executed : " + query.getQueryObject().toString());
+        return aggregationResultsFactory.countResult(mongoOperations.count(query, getMongoCollectionName(resourceUri)));
+    }
+
+    @Override
+    public JsonElement average(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
+        List<DBObject> results =  aggregate(resourceUri, Optional.ofNullable(resourceQueries), group().avg(field).as(AVERAGE).count().as(COUNT));
+        return fieldNotExists(resourceUri, field, results, AVERAGE) ? aggregationResultsFactory.averageResult(Optional.empty()) :
+                aggregationResultsFactory.averageResult(getAggregationResultValue(AVERAGE, results, resourceUri, field));
+    }
+
+    @Override
+        public JsonElement sum(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
+        List<DBObject> results = aggregate(resourceUri, Optional.ofNullable(resourceQueries), group().sum(field).as(SUM).count().as(COUNT));
+        return aggregationResultsFactory.sumResult(getAggregationResultValue(SUM, results, resourceUri, field));
+    }
+
+
+    private Optional<Double> getAggregationResultValue(String operator, List<DBObject> results, ResourceUri resourceUri, String field) {
+        if(!results.isEmpty()) {
+            DBObject result = results.get(0);
+            if(isValidAggregationResult(result, resourceUri, field, operator)) {
+                return Optional.ofNullable((Number) result.get(operator)).map(Number::doubleValue);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean isValidAggregationResult(DBObject result, ResourceUri resourceUri, String field, String operator) {
+        Object aggregation = result.get(operator);
+        int count = (int) result.get(COUNT);
+
+        return !(count == 0 || ((aggregation.equals(0) || aggregation.equals(0.0)) && !collectionHasAtLeastOneEntryWithNumericInField(resourceUri, field)));
+    }
+
+    protected boolean fieldNotExists(ResourceUri resourceUri, String field, List<DBObject> results, String type) {
+        Query query = Query.query(Criteria.where(field).exists(true));
+
+        return ((results.get(0).get(type).equals(0) || results.get(0).get(type).equals(0.0)) && mongoOperations.count(query, getMongoCollectionName(resourceUri)) == 0);
+    }
+
+    protected boolean collectionHasAtLeastOneEntryWithNumericInField(ResourceUri resourceUri, String field) {
+        Query query = Query.query(Criteria.where(field).type(MONGO_DOUBLE_TYPE).orOperator(Criteria.where(field).type(MONGO_INT_TYPE)
+                .orOperator(Criteria.where(field).type(MONGO_LONG_TYPE))));
+
+        return mongoOperations.count(query, getMongoCollectionName(resourceUri)) != 0;
+    }
+
+    @Override
+    public JsonElement max(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
+        List<DBObject> results = aggregate(resourceUri, Optional.ofNullable(resourceQueries), group().max(field).as("max"));
+        return aggregationResultsFactory.maxResult(results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0).get("max")));
+    }
+
+    @Override
+    public JsonElement min(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
+        List<DBObject> results = aggregate(resourceUri, Optional.ofNullable(resourceQueries), group().min(field).as("min"));
+        return aggregationResultsFactory.minResult(results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0).get("min")));
+    }
+
+    @Override
+    public JsonArray combine(ResourceUri resourceUri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination,
+                             Optional<Sort> sort, String field, String expression) throws InvalidApiParamException {
+
+        MongoAggregationBuilder builder = new MongoAggregationBuilder();
+        builder.match(resourceUri, resourceQueries);
+
+        builder.projection(field, expression);
+
+        if (sort.isPresent()) {
+            builder.sort(sort.get().getDirection().toString(), sort.get().getField());
+        }
+
+        if (pagination.isPresent()) {
+            builder.pagination(pagination.get());
+        }
+
+        Aggregation aggregation = builder.build();
+        if(allowDiskUse){
+            aggregation = withAllowDiskUseOption(aggregation);
+        }
+
+        List<JsonObject> results;
+        try {
+            results = mongoOperations.aggregate(aggregation, getMongoCollectionName(resourceUri), JsonObject.class)
+                    .getMappedResults();
+        } catch (SpelParseException spe) {
+            throw new InvalidApiParamException(spe.getMessage());
+        }
+
+        return JsonUtils.convertToArray(results.stream().map(result -> {
+            JsonObject document = result.get(MongoAggregationBuilder.DOCUMENT).getAsJsonObject();
+            document.add(field, result.get(field));
+            return document;
+        }).collect(Collectors.toList()));
+    }
+
+    @Override
+    public JsonElement histogram(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, Optional<Pagination> pagination,
+                                 Optional<Sort> sortParam, String field) {
+        AggregationOperation[] aggregations = {
+                group(Fields.from(Fields.field(field, field))).push("$_id").as("ids"),
+                new ExposingFieldsCustomAggregationOperation(new BasicDBObject("$project", new BasicDBObject(COUNT, new BasicDBObject(
+                        "$size", "$ids")))) {
+                    @Override
+                    public ExposedFields getFields() {
+                        return ExposedFields.synthetic(Fields.fields(COUNT));
+                    }
+                }};
+
+        if (sortParam.isPresent()) {
+            Direction direction = Direction.ASC;
+            if (sortParam.get().getDirection() == Sort.Direction.DESC) {
+                direction = Direction.DESC;
+            }
+            aggregations = ArrayUtils.add(aggregations, sort(direction, sortParam.get().getField()));
+        }
+
+        if (pagination.isPresent()) {
+            aggregations = ArrayUtils.addAll(aggregations, skip(pagination.get().getPage() * pagination.get().getPageSize()),
+                    limit(pagination.get().getPageSize()));
+        }
+
+        List<HistogramEntry> results = aggregate(resourceUri, Optional.ofNullable(resourceQueries), aggregations).stream()
+                .map(result -> toHistogramEntry(result, field)).collect(Collectors.toList());
+        return aggregationResultsFactory.histogramResult(results.toArray(new HistogramEntry[results.size()]));
+    }
+
+    private HistogramEntry toHistogramEntry(DBObject result, String... fields) {
+        long count = ((Number) result.get(COUNT)).longValue();
+        Map<String, Object> values;
+        if (fields.length == 1) {
+            values = Collections.singletonMap(fields[0], result.get("_id"));
+        } else {
+            values = new HashMap<>(fields.length);
+            result.keySet().stream().filter(f -> !COUNT.equals(f)).forEach(f -> values.put(f, result.get(f)));
+        }
+
+        return new HistogramEntry(count, values);
+    }
+
+
+    private String getMongoCollectionName(ResourceUri resourceUri) {
+        return namespaceNormalizer.normalize(resourceUri.getDomain()) + DOMAIN_CONCATENATION +
+                Optional.ofNullable(namespaceNormalizer.normalize(resourceUri.getType()))
+                        .map(type -> type + Optional.ofNullable(resourceUri.getRelation())
+                                .map(relation -> RELATION_CONCATENATION + namespaceNormalizer.normalize(relation)).orElse(EMPTY_STRING))
+                        .orElse(EMPTY_STRING);
+    }
+
+    private class CustomAggregationOperation implements AggregationOperation {
+        private final DBObject operation;
+
+        public CustomAggregationOperation(DBObject operation) {
+            this.operation = operation;
+        }
+
+        @Override
+        public DBObject toDBObject(AggregationOperationContext context) {
+            return context.getMappedObject(operation);
+        }
+    }
+
+    private class ExposingFieldsCustomAggregationOperation extends CustomAggregationOperation implements FieldsExposingAggregationOperation {
+
+        public ExposingFieldsCustomAggregationOperation(DBObject operation) {
+            super(operation);
+        }
+
+        @Override
+        public ExposedFields getFields() {
+            return null;
+        }
+    }
+}

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/MongoResmiDao.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/MongoResmiDao.java
@@ -1,141 +1,39 @@
 package io.corbel.resources.rem.dao;
 
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import io.corbel.lib.mongo.JsonObjectMongoWriteConverter;
-import io.corbel.lib.mongo.utils.GsonUtil;
-import io.corbel.lib.queries.mongo.builder.CriteriaBuilder;
-import io.corbel.lib.queries.request.*;
+import io.corbel.lib.queries.request.Pagination;
+import io.corbel.lib.queries.request.ResourceQuery;
+import io.corbel.lib.queries.request.Sort;
 import io.corbel.resources.rem.dao.builder.MongoAggregationBuilder;
-import io.corbel.resources.rem.model.GenericDocument;
-import io.corbel.resources.rem.model.RelationDocument;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.resmi.exception.InvalidApiParamException;
 import io.corbel.resources.rem.utils.JsonUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.mongodb.core.FindAndModifyOptions;
-import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.*;
-import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.expression.spel.SpelParseException;
 
-import javax.annotation.OverridingMethodsMustInvokeSuper;
-import java.util.*;
-import java.util.regex.PatternSyntaxException;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
-
-
 /**
- * @author Alberto J. Rubio
- *
+ * @author Alexander De Leon (alex.deleon@devialab.com)
  */
-public class MongoResmiDao implements ResmiDao {
+public interface MongoResmiDao extends ResmiDao {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MongoResmiDao.class);
-
-    private static final String ID = "id";
-    private static final String _ID = "_id";
-
-    private static final String RELATION_CONCATENATION = ".";
-    private static final String DOMAIN_CONCATENATION = "__";
-    private static final String EMPTY_STRING = "";
-    private static final String EXPIRE_AT = "_expireAt";
-    private static final String CREATED_AT = "_createdAt";
-    private static final String COUNT = "count";
-    private static final String AVERAGE = "average";
-    private static final String SUM = "sum";
-    public static final String $INC = "$inc";
-
-    private static final int MONGO_DOUBLE_TYPE = 1;
-    private static final int MONGO_INT_TYPE = 16;
-    private static final int MONGO_LONG_TYPE = 18;
-
-
-    private final MongoOperations mongoOperations;
-    private final JsonObjectMongoWriteConverter jsonObjectMongoWriteConverter;
-    private final NamespaceNormalizer namespaceNormalizer;
-    private final ResmiOrder resmiOrder;
-    private final AggregationResultsFactory<JsonElement> aggregationResultsFactory;
-    private final boolean allowDiskUse;
-
-    public MongoResmiDao(MongoOperations mongoOperations, JsonObjectMongoWriteConverter jsonObjectMongoWriteConverter,
-                         NamespaceNormalizer namespaceNormalizer, ResmiOrder resmiOrder, AggregationResultsFactory<JsonElement> aggregationResultsFactory,
-                         boolean allowDiskUse) {
-        this.mongoOperations = mongoOperations;
-        this.jsonObjectMongoWriteConverter = jsonObjectMongoWriteConverter;
-        this.namespaceNormalizer = namespaceNormalizer;
-        this.resmiOrder = resmiOrder;
-        this.aggregationResultsFactory = aggregationResultsFactory;
-        this.allowDiskUse = allowDiskUse;
+    default JsonObject findResource(ResourceUri uri) {
+        return findResource(uri, JsonObject.class);
     }
 
-    @Override
-    public boolean existsResources(ResourceUri uri) {
-        return mongoOperations.exists(Query.query(Criteria.where(_ID).is(uri.getTypeId())), getMongoCollectionName(uri));
+    default JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort) throws InvalidApiParamException {
+        return JsonUtils.convertToArray(findCollection(uri, resourceQueries, textSearch, pagination, sort, JsonObject.class));
     }
 
-    @Override
-    public JsonObject findResource(ResourceUri uri) {
-        return mongoOperations.findById(uri.getTypeId(), JsonObject.class, getMongoCollectionName(uri));
-    }
 
-    @Override
-    public JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort) throws InvalidApiParamException {
-        final MongoResmiQueryBuilder mongoResmiQueryBuilder = new MongoResmiQueryBuilder();
-        try {
-            mongoResmiQueryBuilder.query(resourceQueries.orElse(null)).pagination(pagination.orElse(null)).sort(sort.orElse(null));
-        } catch (PatternSyntaxException pse) {
-            throw new InvalidApiParamException(pse.getMessage());
-        }
-        if (textSearch.isPresent() && StringUtils.isNoneEmpty(textSearch.get()))
-        {
-            mongoResmiQueryBuilder.textSearch(textSearch.get());
-        }
-        final Query query = mongoResmiQueryBuilder.build();
-        LOG.debug("findCollection Query executed : " + query.getQueryObject().toString());
-        return JsonUtils.convertToArray(mongoOperations.find(query, JsonObject.class, getMongoCollectionName(uri)));
-    }
-
-    @Override
-    public JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort) throws InvalidApiParamException {
-        final MongoResmiQueryBuilder mongoResmiQueryBuilder = new MongoResmiQueryBuilder();
-
-        if (uri.getRelationId() != null) {
-            mongoResmiQueryBuilder.relationDestinationId(uri.getRelationId());
-        }
-
-        try {
-            mongoResmiQueryBuilder.relationSubjectId(uri).query(resourceQueries.orElse(null)).pagination(pagination.orElse(null))
-                    .sort(sort.orElse(null));
-        } catch (PatternSyntaxException pse) {
-            throw new InvalidApiParamException(pse.getMessage());
-        }
-
-
-        if (textSearch.isPresent() && StringUtils.isNoneEmpty(textSearch.get())) {
-            mongoResmiQueryBuilder.textSearch(textSearch.get());
-        }
-
-        final Query query = mongoResmiQueryBuilder.build();
-        query.fields().exclude(_ID);
-
-        LOG.debug("findRelation Query executed : " + query.getQueryObject().toString());
-        JsonArray result = renameIds(JsonUtils.convertToArray(mongoOperations.find(query, JsonObject.class, getMongoCollectionName(uri))), uri.isTypeWildcard());
+    default JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort) throws InvalidApiParamException {
+        JsonArray result = ResmiDaoHelper.renameIds(JsonUtils.convertToArray(findRelation(uri, resourceQueries, textSearch, pagination, sort, JsonObject.class)), uri.isTypeWildcard());
 
         if (uri.getRelationId() != null) {
             if (result.size() == 1) {
@@ -148,443 +46,38 @@ public class MongoResmiDao implements ResmiDao {
         return result;
     }
 
-    @Override
-    public JsonArray findCollectionWithGroup(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, List<String> groups, boolean first) throws InvalidApiParamException {
-        Aggregation aggregation = buildGroupAggregation(uri, resourceQueries, textSearch, pagination, sort, groups, first);
-        List<JsonObject> result = mongoOperations.aggregate(aggregation, getMongoCollectionName(uri), JsonObject.class).getMappedResults();
+    default JsonArray findCollectionWithGroup(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, List<String> groups, boolean first) throws InvalidApiParamException {
+        if (sort.isPresent() && first) {
+            sort = Optional.of(new Sort(sort.get().getDirection().name(), "first."+sort.get().getField()));
+        }
+        List<JsonObject> result = aggregate(uri, resourceQueries, textSearch, pagination, sort, JsonObject.class);
         return JsonUtils.convertToArray(first ? extractDocuments(result) : result);
     }
 
-    @Override
-    public JsonArray findRelationWithGroup(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, List<String> groups, boolean first) throws InvalidApiParamException {
-        Aggregation aggregation = buildGroupAggregation(uri, resourceQueries, textSearch, pagination, sort, groups, first);
-        List<JsonObject> result = mongoOperations.aggregate(aggregation, getMongoCollectionName(uri), JsonObject.class).getMappedResults();
-        return renameIds(JsonUtils.convertToArray(first ? extractDocuments(result) : result), uri.isTypeWildcard());
+    default JsonArray findRelationWithGroup(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, List<String> groups, boolean first) throws InvalidApiParamException {
+        if (sort.isPresent() && first) {
+            sort = Optional.of(new Sort(sort.get().getDirection().name(), "first."+sort.get().getField()));
+        }
+        List<JsonObject> result = aggregate(uri, resourceQueries, textSearch, pagination, sort, JsonObject.class);
+        return ResmiDaoHelper.renameIds(JsonUtils.convertToArray(first ? extractDocuments(result) : result), uri.isTypeWildcard());
     }
 
 
-    private Aggregation buildGroupAggregation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, List<String> fields, boolean first) throws InvalidApiParamException {
-        MongoAggregationBuilder builder = new MongoAggregationBuilder();
-        builder.match(uri, resourceQueries, textSearch);
-        builder.group(fields, first);
+    <T> T findResource(ResourceUri uri, Class<T> entityClass);
 
-        if (sort.isPresent()) {
-            builder.sort(sort.get().getDirection().toString(), (first ? "first." : "") + sort.get().getField());
-        }
+    <T> List<T> findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass) throws InvalidApiParamException;
 
-        if (pagination.isPresent()) {
-            builder.pagination(pagination.get());
-        }
+    <T> List<T> findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass)throws InvalidApiParamException;
 
-        if(allowDiskUse) {
-            return withAllowDiskUseOption(builder.build());
-        }
-        return builder.build();
-    }
+    <T> List<T> aggregate(ResourceUri resourceUri, Optional<List<ResourceQuery>> resourceQueries, Optional<String> textSearch, Optional<Pagination> pagination, Optional<Sort> sort, Class<T> entityClass, AggregationOperation... operations) throws InvalidApiParamException;
 
-    private Aggregation withAllowDiskUseOption(Aggregation aggregation) {
-        return aggregation.withOptions(new AggregationOptions.Builder().allowDiskUse(true).build());
-    }
+    <T> List<T> findAll(ResourceUri uri, Class<T> entityClass);
 
-    private List<JsonObject> extractDocuments(List<JsonObject> results) {
+    void ensureExpireIndex(ResourceUri uri);
+
+    void ensureIndex(ResourceUri uri, IndexDefinition indexDefinition);
+
+    static List<JsonObject> extractDocuments(List<JsonObject> results) {
         return results.stream().map(result -> result.get(MongoAggregationBuilder.REFERENCE).getAsJsonObject()).collect(Collectors.toList());
-    }
-
-    @Override
-    public <T> List<T> findAll(ResourceUri uri, Class<T> entityClass) {
-        return mongoOperations.findAll(entityClass, getMongoCollectionName(uri));
-    }
-
-    @Override
-    public void updateCollection(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
-        updateMulti(getMongoCollectionName(uri), entity, Optional.of(resourceQueries));
-    }
-
-    @Override
-    public void updateResource(ResourceUri uri, JsonObject entity) {
-        findAndModify(getMongoCollectionName(uri), Optional.of(uri.getTypeId()), entity, true, Optional.empty());
-    }
-
-    @Override
-    public boolean conditionalUpdateResource(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
-        JsonObject saved = findAndModify(getMongoCollectionName(uri), Optional.of(uri.getTypeId()), entity, false, Optional.of(resourceQueries));
-        return saved != null;
-    }
-
-    private void updateMulti(String collection, JsonObject entity, Optional<List<ResourceQuery>> resourceQueries) {
-        Update update = updateFromJsonObject(entity, Optional.empty());
-        Query query = getQueryFromResourceQuery(resourceQueries, Optional.empty());
-        mongoOperations.updateMulti(query, update, JsonObject.class, collection);
-    }
-
-    private Query getQueryFromResourceQuery(Optional<List<ResourceQuery>> resourceQueries, Optional<String> id) {
-        MongoResmiQueryBuilder builder = id.map(identifier -> new MongoResmiQueryBuilder().id(identifier)).orElse(new MongoResmiQueryBuilder());
-
-        if (resourceQueries.isPresent()) {
-            builder.query(resourceQueries.get());
-        }
-
-        return builder.build();
-    }
-
-    private JsonObject findAndModify(String collection, Optional<String> id, JsonObject entity, boolean upsert, Optional<List<ResourceQuery>> resourceQueries) {
-        Update update = updateFromJsonObject(entity, id);
-        Query query = (id.isPresent()) ? getQueryFromResourceQuery(resourceQueries, id) : Query.query(Criteria.where(_ID).exists(false));
-
-        return mongoOperations.findAndModify(query, update, FindAndModifyOptions.options().upsert(upsert).returnNew(true), JsonObject.class, collection);
-    }
-
-    @Override
-    public void saveResource(ResourceUri uri, Object entity) {
-        mongoOperations.save(entity, getMongoCollectionName(uri));
-    }
-
-    @SuppressWarnings("unchecked")
-    private Update updateFromJsonObject(JsonObject entity, Optional<String> id) {
-        Update update = new Update();
-
-        if (id.isPresent()) {
-            entity.remove(ID);
-            if (entity.entrySet().isEmpty()) {
-                update.set(_ID, id);
-            }
-        }
-
-        if (entity.has(CREATED_AT)) {
-            JsonPrimitive createdAt = entity.get(CREATED_AT).getAsJsonPrimitive();
-            entity.remove(CREATED_AT);
-            update.setOnInsert(CREATED_AT, GsonUtil.getPrimitive(createdAt));
-        }
-
-        if (entity.has($INC) && entity.get($INC).isJsonObject()) {
-            for (Map.Entry<String, JsonElement> entry : entity.getAsJsonObject($INC).entrySet()) {
-                update.inc(entry.getKey(), entry.getValue().getAsLong());
-            }
-            entity.remove($INC);
-        }
-
-        jsonObjectMongoWriteConverter.convert(entity).toMap().forEach((key, value) -> update.set((String) key, value));
-        entity.entrySet().stream().filter(entry -> entry.getValue().isJsonNull()).forEach(entry -> update.unset(entry.getKey()));
-
-        return update;
-    }
-
-    @Override
-    public void upsertRelation(ResourceUri uri, JsonObject entity) throws NotFoundException {
-        if (!existsResources(new ResourceUri(uri.getDomain(), uri.getType(), uri.getTypeId()))) {
-            throw new NotFoundException("The resource does not exist");
-        }
-
-        JsonObject relationJson = JsonRelation.create(uri.getTypeId(), uri.getRelationId(), entity);
-        JsonObject storedRelation = findModifyOrCreateRelation(uri, relationJson);
-
-        if (!storedRelation.has("_order")) {
-            JsonObject order = new JsonObject();
-            resmiOrder.addNextOrderInRelation(uri, order);
-            findAndModify(getMongoCollectionName(uri), Optional.ofNullable(storedRelation.get("id").getAsString()), order, false,
-                    Optional.empty());
-        }
-    }
-
-    @Override
-    public boolean conditionalUpdateRelation(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries) {
-        JsonObject saved = findModifyRelation(uri, entity, resourceQueries);
-        return saved != null;
-    }
-
-    private JsonObject findModifyOrCreateRelation(ResourceUri uri, JsonObject entity) {
-        if (uri.getRelationId() != null) {
-            Criteria criteria = Criteria.where(JsonRelation._SRC_ID).is(uri.getTypeId()).and(JsonRelation._DST_ID).is(uri.getRelationId());
-            Update update = updateFromJsonObject(entity, Optional.<String>empty());
-            update.set(JsonRelation._SRC_ID, uri.getTypeId());
-            update.set(JsonRelation._DST_ID, uri.getRelationId());
-            return mongoOperations.findAndModify(new Query(criteria), update, FindAndModifyOptions.options().upsert(true).returnNew(true),
-                    JsonObject.class, getMongoCollectionName(uri));
-        } else {
-            mongoOperations.save(entity, getMongoCollectionName(uri));
-            return entity;
-        }
-    }
-    private JsonObject findModifyRelation(ResourceUri uri, JsonObject entity,  List<ResourceQuery>
-            resourceQueries) {
-        Query query = new MongoResmiQueryBuilder().query(resourceQueries).build();
-        Criteria criteria = Criteria.where(JsonRelation._SRC_ID).is(uri.getTypeId()).and(JsonRelation._DST_ID).is(uri.getRelationId());
-        query.addCriteria(criteria);
-        Update update = updateFromJsonObject(entity, Optional.<String>empty());
-        update.set(JsonRelation._SRC_ID, uri.getTypeId());
-        update.set(JsonRelation._DST_ID, uri.getRelationId());
-        return mongoOperations.findAndModify(query, update, FindAndModifyOptions.options().upsert(false).returnNew
-                        (true),
-                JsonObject.class, getMongoCollectionName(uri));
-    }
-
-    @Override
-    public void ensureExpireIndex(ResourceUri uri) {
-        mongoOperations.indexOps(getMongoCollectionName(uri)).ensureIndex(new Index().on(EXPIRE_AT, Direction.ASC).expire(0));
-    }
-
-    @Override
-    public void ensureIndex(ResourceUri uri, IndexDefinition indexDefinition) {
-        mongoOperations.indexOps(getMongoCollectionName(uri)).ensureIndex(indexDefinition);
-    }
-
-    /*
-     * TODO: This should be refactor out of here (alex 31.01.14)
-     */
-    private JsonArray renameIds(JsonArray array, boolean wildcard) {
-        for (JsonElement element : array) {
-            if (element.isJsonObject()) {
-                JsonObject object = element.getAsJsonObject();
-                renameIds(object, wildcard);
-            }
-        }
-        return array;
-    }
-
-    private JsonElement renameIds(JsonObject object, boolean wildcard) {
-        object.add("id", object.get(JsonRelation._DST_ID));
-        object.remove(JsonRelation._DST_ID);
-        if (!wildcard) {
-            object.remove(JsonRelation._SRC_ID);
-        }
-        return object;
-    }
-
-    @Override
-    public JsonObject deleteResource(ResourceUri uri) {
-        Criteria criteria = Criteria.where(_ID).is(uri.getTypeId());
-        return findAndRemove(uri, criteria);
-    }
-
-    @Override
-    public List<GenericDocument> deleteCollection(ResourceUri uri, Optional<List<ResourceQuery>> queries) {
-        List<ResourceQuery> resourceQueries = queries.orElse(Collections.<ResourceQuery>emptyList());
-        Criteria criteria = CriteriaBuilder.buildFromResourceQueries(resourceQueries);
-        return findAllAndRemove(uri, criteria, GenericDocument.class);
-    }
-
-    @Override
-    public List<GenericDocument> deleteRelation(ResourceUri uri, Optional<List<ResourceQuery>> queries) {
-        List<ResourceQuery> resourceQueries = queries.orElse(Collections.<ResourceQuery>emptyList());
-        Criteria criteria = CriteriaBuilder.buildFromResourceQueries(resourceQueries);
-        if (!uri.isTypeWildcard()) {
-            criteria = criteria.and(JsonRelation._SRC_ID).is(uri.getTypeId());
-        }
-        if (uri.getRelationId() != null) {
-            criteria = criteria.and(JsonRelation._DST_ID).is(uri.getRelationId());
-        }
-
-        return findAllAndRemove(uri, criteria, RelationDocument.class).stream().map(document -> {
-            return new GenericDocument().setId(document.getDstId());
-        }).collect(Collectors.<GenericDocument>toList());
-    }
-
-    private <T extends GenericDocument> List<T> findAllAndRemove(ResourceUri resourceUri, Criteria criteria, Class<T> clazz) {
-        return mongoOperations.findAllAndRemove(new Query(criteria), clazz, getMongoCollectionName(resourceUri));
-    }
-
-    private JsonObject findAndRemove(ResourceUri resourceUri, Criteria criteria) {
-        return mongoOperations.findAndRemove(new Query(criteria), JsonObject.class, getMongoCollectionName(resourceUri));
-    }
-
-
-    @Override
-    public void moveRelation(ResourceUri uri, RelationMoveOperation relationMoveOperation) {
-        resmiOrder.moveRelation(uri, relationMoveOperation);
-    }
-
-
-    @Override
-    public JsonElement count(ResourceUri resourceUri, List<ResourceQuery> resourceQueries) {
-        Query query = new MongoResmiQueryBuilder().relationSubjectId(resourceUri).query(resourceQueries).build();
-        if (resourceUri.isRelation()) {
-            query.fields().exclude(_ID).exclude(JsonRelation._SRC_ID);
-        }
-        LOG.debug("Query executed : " + query.getQueryObject().toString());
-        return aggregationResultsFactory.countResult(mongoOperations.count(query, getMongoCollectionName(resourceUri)));
-    }
-
-    @Override
-    public JsonElement average(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
-        List<DBObject> results = aggregate(resourceUri, resourceQueries, group().avg(field).as(AVERAGE).count().as(COUNT));
-
-        return fieldNotExists(resourceUri, field, results, AVERAGE) ? aggregationResultsFactory.averageResult(Optional.empty()) :
-                aggregationResultsFactory.averageResult(getAggregationResultValue(AVERAGE, results, resourceUri, field));
-    }
-
-    @Override
-        public JsonElement sum(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
-        List<DBObject> results = aggregate(resourceUri, resourceQueries, group().sum(field).as(SUM).count().as(COUNT));
-
-        return aggregationResultsFactory.sumResult(getAggregationResultValue(SUM, results, resourceUri, field));
-    }
-
-
-    private Optional<Double> getAggregationResultValue(String operator, List<DBObject> results, ResourceUri resourceUri, String field) {
-        if(!results.isEmpty()) {
-            DBObject result = results.get(0);
-            if(isValidAggregationResult(result, resourceUri, field, operator)) {
-                return Optional.ofNullable((Number) result.get(operator)).map(Number::doubleValue);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private boolean isValidAggregationResult(DBObject result, ResourceUri resourceUri, String field, String operator) {
-        Object aggregation = result.get(operator);
-        int count = (int) result.get(COUNT);
-
-        return !(count == 0 || ((aggregation.equals(0) || aggregation.equals(0.0)) && !collectionHasAtLeastOneEntryWithNumericInField(resourceUri, field)));
-    }
-
-    protected boolean fieldNotExists(ResourceUri resourceUri, String field, List<DBObject> results, String type) {
-        Query query = Query.query(Criteria.where(field).exists(true));
-
-        return ((results.get(0).get(type).equals(0) || results.get(0).get(type).equals(0.0)) && mongoOperations.count(query, getMongoCollectionName(resourceUri)) == 0);
-    }
-
-    protected boolean collectionHasAtLeastOneEntryWithNumericInField(ResourceUri resourceUri, String field) {
-        Query query = Query.query(Criteria.where(field).type(MONGO_DOUBLE_TYPE).orOperator(Criteria.where(field).type(MONGO_INT_TYPE)
-                .orOperator(Criteria.where(field).type(MONGO_LONG_TYPE))));
-
-        return mongoOperations.count(query, getMongoCollectionName(resourceUri)) != 0;
-    }
-
-    @Override
-    public JsonElement max(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
-        List<DBObject> results = aggregate(resourceUri, resourceQueries, group().max(field).as("max"));
-        return aggregationResultsFactory.maxResult(results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0).get("max")));
-    }
-
-    @Override
-    public JsonElement min(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, String field) {
-        List<DBObject> results = aggregate(resourceUri, resourceQueries, group().min(field).as("min"));
-        return aggregationResultsFactory.minResult(results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0).get("min")));
-    }
-
-    @Override
-    public JsonArray combine(ResourceUri resourceUri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination,
-                             Optional<Sort> sort, String field, String expression) throws InvalidApiParamException {
-
-        MongoAggregationBuilder builder = new MongoAggregationBuilder();
-        builder.match(resourceUri, resourceQueries);
-
-        builder.projection(field, expression);
-
-        if (sort.isPresent()) {
-            builder.sort(sort.get().getDirection().toString(), sort.get().getField());
-        }
-
-        if (pagination.isPresent()) {
-            builder.pagination(pagination.get());
-        }
-
-        Aggregation aggregation = builder.build();
-        if(allowDiskUse){
-            aggregation = withAllowDiskUseOption(aggregation);
-        }
-
-        List<JsonObject> results;
-        try {
-            results = mongoOperations.aggregate(aggregation, getMongoCollectionName(resourceUri), JsonObject.class)
-                    .getMappedResults();
-        } catch (SpelParseException spe) {
-            throw new InvalidApiParamException(spe.getMessage());
-        }
-
-        return JsonUtils.convertToArray(results.stream().map(result -> {
-            JsonObject document = result.get(MongoAggregationBuilder.DOCUMENT).getAsJsonObject();
-            document.add(field, result.get(field));
-            return document;
-        }).collect(Collectors.toList()));
-    }
-
-    @Override
-    public JsonElement histogram(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, Optional<Pagination> pagination,
-                                 Optional<Sort> sortParam, String field) {
-        AggregationOperation[] aggregations = {
-                group(Fields.from(Fields.field(field, field))).push("$_id").as("ids"),
-                new ExposingFieldsCustomAggregationOperation(new BasicDBObject("$project", new BasicDBObject(COUNT, new BasicDBObject(
-                        "$size", "$ids")))) {
-                    @Override
-                    public ExposedFields getFields() {
-                        return ExposedFields.synthetic(Fields.fields(COUNT));
-                    }
-                }};
-
-        if (sortParam.isPresent()) {
-            Direction direction = Direction.ASC;
-            if (sortParam.get().getDirection() == Sort.Direction.DESC) {
-                direction = Direction.DESC;
-            }
-            aggregations = ArrayUtils.add(aggregations, sort(direction, sortParam.get().getField()));
-        }
-
-        if (pagination.isPresent()) {
-            aggregations = ArrayUtils.addAll(aggregations, skip(pagination.get().getPage() * pagination.get().getPageSize()),
-                    limit(pagination.get().getPageSize()));
-        }
-
-        List<HistogramEntry> results = aggregate(resourceUri, resourceQueries, aggregations).stream()
-                .map(result -> toHistogramEntry(result, field)).collect(Collectors.toList());
-        return aggregationResultsFactory.histogramResult(results.toArray(new HistogramEntry[results.size()]));
-    }
-
-    private HistogramEntry toHistogramEntry(DBObject result, String... fields) {
-        long count = ((Number) result.get(COUNT)).longValue();
-        Map<String, Object> values;
-        if (fields.length == 1) {
-            values = Collections.singletonMap(fields[0], result.get("_id"));
-        } else {
-            values = new HashMap<>(fields.length);
-            result.keySet().stream().filter(f -> !COUNT.equals(f)).forEach(f -> values.put(f, result.get(f)));
-        }
-
-        return new HistogramEntry(count, values);
-    }
-
-    private List<DBObject> aggregate(ResourceUri resourceUri, List<ResourceQuery> resourceQueries, AggregationOperation... operations) {
-        Criteria criterias = CriteriaBuilder.buildFromResourceQueries(resourceQueries);
-        if (resourceUri.isRelation() && !resourceUri.isTypeWildcard()) {
-            criterias = criterias.and(JsonRelation._SRC_ID).is(resourceUri.getTypeId());
-        }
-        List<AggregationOperation> aggregations = new ArrayList<>(operations.length + 1);
-        aggregations.add(Aggregation.match(criterias));
-        aggregations.addAll(Arrays.asList(operations));
-        return mongoOperations.aggregate(newAggregation(aggregations), getMongoCollectionName(resourceUri), DBObject.class)
-                .getMappedResults();
-    }
-
-    private String getMongoCollectionName(ResourceUri resourceUri) {
-        return namespaceNormalizer.normalize(resourceUri.getDomain()) + DOMAIN_CONCATENATION +
-                Optional.ofNullable(namespaceNormalizer.normalize(resourceUri.getType()))
-                        .map(type -> type + Optional.ofNullable(resourceUri.getRelation())
-                                .map(relation -> RELATION_CONCATENATION + namespaceNormalizer.normalize(relation)).orElse(EMPTY_STRING))
-                        .orElse(EMPTY_STRING);
-    }
-
-    private class CustomAggregationOperation implements AggregationOperation {
-        private final DBObject operation;
-
-        public CustomAggregationOperation(DBObject operation) {
-            this.operation = operation;
-        }
-
-        @Override
-        public DBObject toDBObject(AggregationOperationContext context) {
-            return context.getMappedObject(operation);
-        }
-    }
-
-    private class ExposingFieldsCustomAggregationOperation extends CustomAggregationOperation implements FieldsExposingAggregationOperation {
-
-        public ExposingFieldsCustomAggregationOperation(DBObject operation) {
-            super(operation);
-        }
-
-        @Override
-        public ExposedFields getFields() {
-            return null;
-        }
     }
 }

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDao.java
@@ -66,11 +66,5 @@ public interface ResmiDao {
 
     void moveRelation(ResourceUri uri, RelationMoveOperation relationMoveOperation);
 
-    <T> List<T> findAll(ResourceUri uri, Class<T> entityClass);
-
     boolean conditionalUpdateRelation(ResourceUri uri, JsonObject entity, List<ResourceQuery> resourceQueries);
-
-    void ensureExpireIndex(ResourceUri uri);
-
-    void ensureIndex(ResourceUri uri, IndexDefinition indexDefinition);
 }

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDaoHelper.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/ResmiDaoHelper.java
@@ -1,0 +1,30 @@
+package io.corbel.resources.rem.dao;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public class ResmiDaoHelper {
+
+    static JsonArray renameIds(JsonArray array, boolean wildcard) {
+        for (JsonElement element : array) {
+            if (element.isJsonObject()) {
+                JsonObject object = element.getAsJsonObject();
+                renameIds(object, wildcard);
+            }
+        }
+        return array;
+    }
+
+    static JsonElement renameIds(JsonObject object, boolean wildcard) {
+        object.add("id", object.get(JsonRelation._DST_ID));
+        object.remove(JsonRelation._DST_ID);
+        if (!wildcard) {
+            object.remove(JsonRelation._SRC_ID);
+        }
+        return object;
+    }
+}

--- a/resmi/src/main/java/io/corbel/resources/rem/dao/builder/MongoAggregationBuilder.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/dao/builder/MongoAggregationBuilder.java
@@ -95,9 +95,14 @@ public class MongoAggregationBuilder {
         return this;
     }
 
-    public Aggregation build() throws InvalidApiParamException {
+    public MongoAggregationBuilder withOperation(AggregationOperation operation) {
+        operations.add(operation);
+        return this;
+    }
+
+    public Aggregation build() {
         if (operations.isEmpty()) {
-            throw new InvalidApiParamException("Cannot build aggregation without operations");
+            throw new IllegalStateException("Cannot build aggregation without operations");
         }
         return Aggregation.newAggregation(operations.toArray(new AggregationOperation[operations.size()]));
     }

--- a/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
@@ -4,6 +4,7 @@ import io.corbel.lib.config.ConfigurationHelper;
 import io.corbel.resources.cli.dsl.ResmiShell;
 import io.corbel.resources.rem.Rem;
 import io.corbel.resources.rem.RemRegistry;
+import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.resmi.ioc.ResmiIoc;
 import io.corbel.resources.rem.resmi.ioc.ResmiRemNames;
 import io.corbel.resources.rem.search.ElasticSearchService;
@@ -34,6 +35,9 @@ import com.codahale.metrics.health.HealthCheck;
         super.init();
         ConfigurationHelper.setConfigurationNamespace(ARTIFACT_ID);
         context = new AnnotationConfigApplicationContext(ResmiIoc.class);
+
+        //publish services
+        serviceLocator.publish(ResmiDao.class, context.getBean(ResmiDao.class));
     }
 
     @Override

--- a/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
@@ -4,6 +4,7 @@ import io.corbel.lib.config.ConfigurationHelper;
 import io.corbel.resources.cli.dsl.ResmiShell;
 import io.corbel.resources.rem.Rem;
 import io.corbel.resources.rem.RemRegistry;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.resmi.ioc.ResmiIoc;
 import io.corbel.resources.rem.resmi.ioc.ResmiRemNames;
@@ -38,6 +39,7 @@ import com.codahale.metrics.health.HealthCheck;
 
         //publish services
         serviceLocator.publish(ResmiDao.class, context.getBean(ResmiDao.class));
+        serviceLocator.publish(MongoResmiDao.class, context.getBean(MongoResmiDao.class));
     }
 
     @Override

--- a/resmi/src/main/java/io/corbel/resources/rem/resmi/ioc/ResmiIoc.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/resmi/ioc/ResmiIoc.java
@@ -8,11 +8,7 @@ import io.corbel.lib.mongo.config.DefaultMongoConfiguration;
 import io.corbel.lib.queries.request.AggregationResultsFactory;
 import io.corbel.lib.queries.request.JsonAggregationResultsFactory;
 import io.corbel.resources.rem.Rem;
-import io.corbel.resources.rem.dao.DefaultResmiOrder;
-import io.corbel.resources.rem.dao.MongoResmiDao;
-import io.corbel.resources.rem.dao.NamespaceNormalizer;
-import io.corbel.resources.rem.dao.ResmiDao;
-import io.corbel.resources.rem.dao.ResmiOrder;
+import io.corbel.resources.rem.dao.*;
 import io.corbel.resources.rem.health.ElasticSearchHealthCheck;
 import io.corbel.resources.rem.resmi.*;
 import io.corbel.resources.rem.search.DefaultElasticSearchService;
@@ -66,9 +62,9 @@ public class ResmiIoc extends DefaultMongoConfiguration {
     }
 
     @Bean
-    public ResmiDao mongoResmiDao(AggregationResultsFactory<JsonElement> aggregationResultsFactory,
-                                  @Value("${resmi.mongodb.aggregations.allowDiskUse}") boolean allowDiskUse) throws Exception {
-        return new MongoResmiDao(mongoTemplate(), getJsonObjectMongoWriteConverter(), getNamespaceNormilizer(), getMongoResmiOrder(),
+    public MongoResmiDao mongoResmiDao(AggregationResultsFactory<JsonElement> aggregationResultsFactory,
+                                       @Value("${resmi.mongodb.aggregations.allowDiskUse}") boolean allowDiskUse) throws Exception {
+        return new DefaultMongoResmiDao(mongoTemplate(), getJsonObjectMongoWriteConverter(), getNamespaceNormilizer(), getMongoResmiOrder(),
                 aggregationResultsFactory, allowDiskUse);
     }
 
@@ -128,7 +124,7 @@ public class ResmiIoc extends DefaultMongoConfiguration {
     }
 
     @Bean
-    public ResmiService resmiService(AggregationResultsFactory<JsonElement> aggregationResultsFactory, ResmiDao resmiDao) throws Exception {
+    public ResmiService resmiService(AggregationResultsFactory<JsonElement> aggregationResultsFactory, MongoResmiDao resmiDao) throws Exception {
         if (elasticSearchEnabled || textSearchMode.equalsIgnoreCase("elasticsearch")) {
             return new WithSearchResmiService(resmiDao, resmiSearch(aggregationResultsFactory), getSearchableFieldsRegistry(), getGson(), getClock());
         } else if (textSearchMode.equalsIgnoreCase("mongo")) {

--- a/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/service/DefaultResmiService.java
@@ -6,9 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.corbel.lib.queries.request.*;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.dao.NotFoundException;
 import io.corbel.resources.rem.dao.RelationMoveOperation;
-import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.request.CollectionParameters;
 import io.corbel.resources.rem.request.RelationParameters;
@@ -34,10 +34,10 @@ public class DefaultResmiService implements ResmiService {
     protected final static Set<String> ATTRIBUTE_NAMES_RESERVED = Sets.newHashSet(_ID, _EXPIRE_AT, _ORDER, _SRC_ID, _DST_ID, _CREATED_AT,
             _UPDATED_AT, _ACL);
 
-    protected final ResmiDao resmiDao;
+    protected final MongoResmiDao resmiDao;
     protected final Clock clock;
 
-    public DefaultResmiService(ResmiDao resmiDao, Clock clock) {
+    public DefaultResmiService(MongoResmiDao resmiDao, Clock clock) {
         this.resmiDao = resmiDao;
         this.clock = clock;
     }

--- a/resmi/src/main/java/io/corbel/resources/rem/service/TextSearchResmiService.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/service/TextSearchResmiService.java
@@ -3,7 +3,7 @@ package io.corbel.resources.rem.service;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import io.corbel.lib.queries.request.Search;
-import io.corbel.resources.rem.dao.ResmiDao;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.request.CollectionParameters;
 import io.corbel.resources.rem.request.RelationParameters;
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 public class TextSearchResmiService extends DefaultResmiService {
 
-    public TextSearchResmiService(ResmiDao resmiDao, Clock clock) {
+    public TextSearchResmiService(MongoResmiDao resmiDao, Clock clock) {
         super(resmiDao, clock);
     }
 

--- a/resmi/src/main/java/io/corbel/resources/rem/service/WithSearchResmiService.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/service/WithSearchResmiService.java
@@ -9,8 +9,8 @@ import io.corbel.lib.queries.request.QueryNode;
 import io.corbel.lib.queries.request.QueryOperator;
 import io.corbel.lib.queries.request.ResourceQuery;
 import io.corbel.lib.queries.request.Search;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.dao.NotFoundException;
-import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.model.GenericDocument;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.model.SearchResource;
@@ -45,8 +45,8 @@ public class WithSearchResmiService extends DefaultResmiService implements Searc
     private final SearchableFieldsRegistry searchableFieldsRegistry;
     private final Gson gson;
 
-    public WithSearchResmiService(ResmiDao resmiDao, ResmiSearch search, SearchableFieldsRegistry searchableFieldsRegistry, Gson gson,
-            Clock clock) {
+    public WithSearchResmiService(MongoResmiDao resmiDao, ResmiSearch search, SearchableFieldsRegistry searchableFieldsRegistry, Gson gson,
+                                  Clock clock) {
         super(resmiDao, clock);
         this.search = search;
         this.searchableFieldsRegistry = searchableFieldsRegistry;

--- a/resmi/src/test/java/io/corbel/resources/rem/dao/builder/MongoAggregationBuilderTest.java
+++ b/resmi/src/test/java/io/corbel/resources/rem/dao/builder/MongoAggregationBuilderTest.java
@@ -140,8 +140,8 @@ public class MongoAggregationBuilderTest {
                 agg.toString());
     }
 
-    @Test(expected = InvalidApiParamException.class)
-    public void testNoOperations() throws InvalidApiParamException {
+    @Test(expected = IllegalStateException.class)
+    public void testNoOperations() {
         builder.build();
     }
 

--- a/resmi/src/test/java/io/corbel/resources/rem/service/DefaultResmiServiceTest.java
+++ b/resmi/src/test/java/io/corbel/resources/rem/service/DefaultResmiServiceTest.java
@@ -5,9 +5,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.corbel.lib.queries.request.*;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.dao.NotFoundException;
 import io.corbel.resources.rem.dao.RelationMoveOperation;
-import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.request.CollectionParameters;
 import io.corbel.resources.rem.request.RelationParameters;
@@ -50,7 +50,8 @@ import static org.mockito.Mockito.*;
 
     String RELATION_URI = "RELATION_URI";
 
-    @Mock ResmiDao resmiDao;
+    @Mock
+    MongoResmiDao resmiDao;
     CollectionParameters collectionParametersMock;
     @Mock ResourceQuery resourceQueryMock;
     @Mock List<ResourceQuery> resourceQueriesMock;

--- a/resmi/src/test/java/io/corbel/resources/rem/service/TextSearchResmiServiceTest.java
+++ b/resmi/src/test/java/io/corbel/resources/rem/service/TextSearchResmiServiceTest.java
@@ -6,7 +6,7 @@ import io.corbel.lib.queries.request.Pagination;
 import io.corbel.lib.queries.request.ResourceQuery;
 import io.corbel.lib.queries.request.Search;
 import io.corbel.lib.queries.request.Sort;
-import io.corbel.resources.rem.dao.ResmiDao;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.request.CollectionParameters;
 import io.corbel.resources.rem.request.RelationParameters;
@@ -34,7 +34,8 @@ import static org.mockito.Mockito.when;
     String ID = "test";
     String TEXT_SEARCH = "textSearchQuery";
 
-    @Mock ResmiDao resmiDao;
+    @Mock
+    MongoResmiDao resmiDao;
     CollectionParameters collectionParametersMock;
     @Mock ResourceQuery resourceQueryMock;
     @Mock List<ResourceQuery> resourceQueriesMock;

--- a/resmi/src/test/java/io/corbel/resources/rem/service/WithSearchResmiServiceTest.java
+++ b/resmi/src/test/java/io/corbel/resources/rem/service/WithSearchResmiServiceTest.java
@@ -11,8 +11,8 @@ import io.corbel.lib.queries.request.Pagination;
 import io.corbel.lib.queries.request.ResourceQuery;
 import io.corbel.lib.queries.request.Search;
 import io.corbel.lib.queries.request.Sort;
+import io.corbel.resources.rem.dao.MongoResmiDao;
 import io.corbel.resources.rem.dao.NotFoundException;
-import io.corbel.resources.rem.dao.ResmiDao;
 import io.corbel.resources.rem.model.ResourceUri;
 import io.corbel.resources.rem.request.CollectionParameters;
 import io.corbel.resources.rem.request.RelationParameters;
@@ -52,7 +52,8 @@ import com.google.gson.JsonObject;
 
     Gson gson = new Gson();
 
-    @Mock ResmiDao resmiDao;
+    @Mock
+    MongoResmiDao resmiDao;
     @Mock ResmiSearch resmiSearch;
     @Mock SearchableFieldsRegistry searchableFieldRegistry;
     CollectionParameters collectionParametersMock;

--- a/resources/src/main/java/io/corbel/resources/ioc/ResourcesIoc.java
+++ b/resources/src/main/java/io/corbel/resources/ioc/ResourcesIoc.java
@@ -6,6 +6,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.container.ContainerRequestFilter;
 
+import io.corbel.resources.rem.service.DefaultServiceLocator;
+import io.corbel.resources.rem.service.ServiceLocator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -108,6 +110,11 @@ import com.google.common.cache.CacheBuilder;
     @Bean
     public RemService getRemService(RemRegistry remRegistry) {
         return new DefaultRemService(remRegistry);
+    }
+
+    @Bean
+    public ServiceLocator serviceLocator() {
+        return new DefaultServiceLocator();
     }
 
     @Bean


### PR DESCRIPTION
This allows REM plugins to publish services that can be used by other plugins.

It is something to use with extreme care because it builds inter-dependencies between plugins.

The main use of this is for RESMI to publish the `ResmiDao` service for other plugins that need an optimized access to the DB. 
