### PR TITLE
Support full console MODE with REMs

### DIFF
--- a/rem-acl/src/main/java/io/corbel/resources/rem/plugin/RemAclPlugin.java
+++ b/rem-acl/src/main/java/io/corbel/resources/rem/plugin/RemAclPlugin.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Component;
     private static final String ACL_CONFIGURATION_COLLECTION = "acl:Configuration";
 
     private String aclConfigurationCollection;
+    private AclConfigurationService aclConfigurationService;
 
     @Override
     protected void init() {
@@ -64,18 +65,17 @@ import org.springframework.stereotype.Component;
         AclResourcesService aclResourcesService = context.getBean(AclResourcesService.class);
         aclResourcesService.setRemService(remService);
 
-        AclConfigurationService aclConfigurationService = context.getBean(AclConfigurationService.class);
+        aclConfigurationService = context.getBean(AclConfigurationService.class);
         aclConfigurationService.setRemService(remService);
         aclConfigurationService.setRemsAndMethods(remsAndMethods);
 
         context.getBean(AclConfigurationEventHandler.class).setAclConfigurationService(aclConfigurationService);
         aclConfigurationCollection = context.getEnvironment().getProperty("rem.acl.configuration.collection", ACL_CONFIGURATION_COLLECTION);
-
-        aclConfigurationService.refreshRegistry();
     }
 
     @Override
     protected void register(RemRegistry registry) {
+        aclConfigurationService.refreshRegistry();
         registry.registerRem(context.getBean(AclRemNames.SETUP_PUT, Rem.class), ".*", MediaType.valueOf(ACL_MEDIA_TYPE), HttpMethod.PUT);
         registry.registerRem(context.getBean(AclRemNames.ADMIN_POST, Rem.class), aclConfigurationCollection, MediaType.ALL, HttpMethod.POST);
         registry.registerRem(context.getBean(AclRemNames.ADMIN_PUT, Rem.class), aclConfigurationCollection, MediaType.ALL, HttpMethod.PUT);

--- a/rem-api/src/main/java/io/corbel/resources/rem/model/Mode.java
+++ b/rem-api/src/main/java/io/corbel/resources/rem/model/Mode.java
@@ -1,5 +1,5 @@
 package io.corbel.resources.rem.model;
 
 public enum Mode {
-    SERVICE, CONSOLE
+    SERVICE, CONSOLE, CONSOLE_FAST
 }

--- a/rem-api/src/main/java/io/corbel/resources/rem/plugin/RemPlugin.java
+++ b/rem-api/src/main/java/io/corbel/resources/rem/plugin/RemPlugin.java
@@ -49,9 +49,9 @@ public abstract class RemPlugin implements InitializingBean {
 
     @Override
     public final void afterPropertiesSet() throws Exception {
-        if (Mode.SERVICE.equals(mode)) {
+        init();
+        if (!Mode.CONSOLE_FAST.equals(mode)) {
             try {
-                init();
                 checkVersion();
                 register(registry);
                 addRelations(relationRegistry);
@@ -64,7 +64,8 @@ public abstract class RemPlugin implements InitializingBean {
                     throw e;
                 }
             }
-        } else {
+        }
+        if(!Mode.SERVICE.equals(mode)) {
             console();
         }
     }

--- a/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
+++ b/resmi/src/main/java/io/corbel/resources/rem/plugin/ResmiRemPlugin.java
@@ -44,7 +44,6 @@ import com.codahale.metrics.health.HealthCheck;
 
     @Override
     protected void console() {
-        init();
         shell.setResmiService(context.getBean(ResmiService.class));
         shell.setElasticSearchService(context.getBean(ElasticSearchService.class));
         shell.setResmiSearch(context.getBean(ResmiSearch.class));

--- a/resources/src/main/java/io/corbel/resources/ResourcesConsoleRunner.java
+++ b/resources/src/main/java/io/corbel/resources/ResourcesConsoleRunner.java
@@ -2,6 +2,7 @@ package io.corbel.resources;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -22,7 +23,10 @@ public class ResourcesConsoleRunner extends Console {
 
     @SuppressWarnings("resource")
     private static Map<String, Object> createShell() {
-        System.setProperty("mode", "console");
+        String mode = Optional.ofNullable(System.getProperty("mode"))
+                .orElse(Optional.ofNullable(System.getenv("MODE"))
+                        .orElse("console_fast"));
+        System.setProperty("mode", mode);
         System.setProperty("conf.namespace", "resources");
         AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(ResourcesIoc.class);
         Map<String, Object> beans = applicationContext.getBeansWithAnnotation(Shell.class);


### PR DESCRIPTION
At some point some had removed the load of the REMs on the console mode. I assume it was for making the console run faster. However, this limits what you can do on the console mode if you don't have access to RESMI via RemService. With this change one can activate full console mode by setting the environment variable `MODE=console` or the system property `mode=console`